### PR TITLE
test: Solution 점유 시 동시성 제어 (Pessimistic Lock 적용)

### DIFF
--- a/src/test/java/startwithco/solutionservice/SolutionServiceApplicationTests.java
+++ b/src/test/java/startwithco/solutionservice/SolutionServiceApplicationTests.java
@@ -2,8 +2,10 @@ package startwithco.solutionservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class SolutionServiceApplicationTests {
 
     @Test

--- a/src/test/java/startwithco/solutionservice/domain/CLOUD.java
+++ b/src/test/java/startwithco/solutionservice/domain/CLOUD.java
@@ -1,0 +1,8 @@
+package startwithco.solutionservice.domain;
+
+public enum CLOUD {
+    PaaS,
+    IaaS,
+    SaaS,
+    CaaS
+}

--- a/src/test/java/startwithco/solutionservice/domain/FIELD.java
+++ b/src/test/java/startwithco/solutionservice/domain/FIELD.java
@@ -1,0 +1,8 @@
+package startwithco.solutionservice.domain;
+
+public enum FIELD {
+    CRM,
+    ERP,
+    HRM,
+    BI
+}

--- a/src/test/java/startwithco/solutionservice/domain/STATUS.java
+++ b/src/test/java/startwithco/solutionservice/domain/STATUS.java
@@ -1,0 +1,6 @@
+package startwithco.solutionservice.domain;
+
+public enum STATUS {
+    OCCUPIED,     // 점유 중
+    WAITING_OCCUPY // 점유 대기
+}

--- a/src/test/java/startwithco/solutionservice/domain/SolutionEntity.java
+++ b/src/test/java/startwithco/solutionservice/domain/SolutionEntity.java
@@ -1,0 +1,57 @@
+package startwithco.solutionservice.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "solution_entity")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SolutionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long solutionSeq;
+
+    @Column(name = "company_seq", nullable = false)
+    private Long companySeq;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private FIELD field;
+
+    @Column(name = "solution_name", nullable = false)
+    private String solutionName;
+
+    @Column(name = "detail_image", nullable = false)
+    private String detailImage;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cloud", nullable = false)
+    private CLOUD cloud;
+
+    @Column(name = "duration", nullable = false)
+    private Long duration;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private STATUS status;
+
+    public void occupy() {
+        if (this.status != STATUS.WAITING_OCCUPY) {
+            throw new IllegalStateException("이미 점유된 솔루션입니다.");
+        }
+
+        this.status = STATUS.OCCUPIED;
+    }
+}

--- a/src/test/java/startwithco/solutionservice/repository/SolutionEntityJpaRepository.java
+++ b/src/test/java/startwithco/solutionservice/repository/SolutionEntityJpaRepository.java
@@ -1,0 +1,19 @@
+package startwithco.solutionservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+import startwithco.solutionservice.domain.SolutionEntity;
+
+import java.util.Optional;
+
+@Repository
+public interface SolutionEntityJpaRepository extends JpaRepository<SolutionEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from SolutionEntity s where s.solutionSeq = :solutionSeq and s.status = 'WAITING_OCCUPY'")
+    Optional<SolutionEntity> findWithLockBySolutionSeqForWaiting(@Param("solutionSeq") Long solutionSeq);
+}

--- a/src/test/java/startwithco/solutionservice/repository/test/SolutionRepositoryTest.java
+++ b/src/test/java/startwithco/solutionservice/repository/test/SolutionRepositoryTest.java
@@ -1,0 +1,54 @@
+package startwithco.solutionservice.repository.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import startwithco.solutionservice.domain.CLOUD;
+import startwithco.solutionservice.domain.FIELD;
+import startwithco.solutionservice.domain.STATUS;
+import startwithco.solutionservice.domain.SolutionEntity;
+import startwithco.solutionservice.repository.SolutionEntityJpaRepository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@DataJpaTest
+@ActiveProfiles("test")
+public class SolutionRepositoryTest {
+    @Autowired
+    private SolutionEntityJpaRepository solutionEntityJpaRepository;
+
+    @Test
+    @DisplayName("솔루션 등록")
+    public void 솔루션_등록() {
+        // given
+        final SolutionEntity solution = SolutionEntity.builder()
+                .companySeq(1L)
+                .field(FIELD.CRM)
+                .solutionName("AI 솔루션")
+                .detailImage("http://image.url/detail.png")
+                .description("AI 기술을 활용한 추천 시스템")
+                .amount(100000L)
+                .cloud(CLOUD.SaaS)
+                .duration(30L)
+                .status(STATUS.OCCUPIED)
+                .build();
+
+        // when
+        SolutionEntity result = solutionEntityJpaRepository.save(solution);
+
+        // then
+        assertThat(result.getSolutionSeq()).isNotNull();
+        assertThat(result.getCompanySeq()).isEqualTo(1L);
+        assertThat(result.getField()).isEqualTo(FIELD.CRM);
+        assertThat(result.getSolutionName()).isEqualTo("AI 솔루션");
+        assertThat(result.getDetailImage()).isEqualTo("http://image.url/detail.png");
+        assertThat(result.getDescription()).isEqualTo("AI 기술을 활용한 추천 시스템");
+        assertThat(result.getAmount()).isEqualTo(100000L);
+        assertThat(result.getCloud()).isEqualTo(CLOUD.SaaS);
+        assertThat(result.getDuration()).isEqualTo(30L);
+        assertThat(result.getStatus()).isEqualTo(STATUS.OCCUPIED);
+    }
+}

--- a/src/test/java/startwithco/solutionservice/service/SolutionService.java
+++ b/src/test/java/startwithco/solutionservice/service/SolutionService.java
@@ -1,0 +1,23 @@
+package startwithco.solutionservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import startwithco.solutionservice.domain.SolutionEntity;
+import startwithco.solutionservice.repository.SolutionEntityJpaRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SolutionService {
+    private final SolutionEntityJpaRepository solutionEntityJpaRepository;
+
+    @Transactional
+    public void findLock(Long solutionSeq) {
+        SolutionEntity solutionEntity = solutionEntityJpaRepository.findWithLockBySolutionSeqForWaiting(solutionSeq)
+                .orElseThrow(() -> new IllegalArgumentException("Solution sequence " + solutionSeq + " not found"));
+
+        solutionEntity.occupy();
+
+        solutionEntityJpaRepository.saveAndFlush(solutionEntity);
+    }
+}

--- a/src/test/java/startwithco/solutionservice/service/test/SolutionServiceTest.java
+++ b/src/test/java/startwithco/solutionservice/service/test/SolutionServiceTest.java
@@ -1,0 +1,91 @@
+package startwithco.solutionservice.service.test;
+
+import jakarta.transaction.Transactional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import startwithco.solutionservice.domain.CLOUD;
+import startwithco.solutionservice.domain.FIELD;
+import startwithco.solutionservice.domain.STATUS;
+import startwithco.solutionservice.domain.SolutionEntity;
+import startwithco.solutionservice.repository.SolutionEntityJpaRepository;
+import startwithco.solutionservice.service.SolutionService;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SolutionServiceTest {
+    @Autowired
+    private SolutionService solutionService;
+
+    @Autowired
+    private SolutionEntityJpaRepository solutionEntityJpaRepository;
+
+    private Long savedId;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        SolutionEntity entity = SolutionEntity.builder()
+                .amount(1000L)
+                .companySeq(1L)
+                .duration(30L)
+                .solutionName("test")
+                .cloud(CLOUD.SaaS)
+                .field(FIELD.ERP)
+                .status(STATUS.WAITING_OCCUPY)
+                .description("desc")
+                .detailImage("image")
+                .build();
+
+        // 저장 후 반환값이 null인지 체크
+        SolutionEntity saved = solutionEntityJpaRepository.save(entity);
+        if (saved == null) throw new IllegalStateException("Save 실패: 엔티티가 null로 반환됨");
+
+        this.savedId = saved.getSolutionSeq();
+    }
+
+    @Test
+    @DisplayName("동시에 점유 시도해도 한 명만 성공해야 함")
+    void 동시에_점유_테스트() throws InterruptedException {
+        // given
+        int threadCount = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    solutionService.findLock(savedId);
+                    System.out.println(Thread.currentThread().getName() + " → 점유 성공");
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    System.out.println(Thread.currentThread().getName() + " → 점유 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        // 한 명만 성공해야 함
+        Assertions.assertThat(successCount.get()).isEqualTo(1);
+
+        // 상태가 OCCUPIED로 바뀌었는지 검증
+        SolutionEntity result = solutionEntityJpaRepository.findById(savedId)
+                .orElseThrow(() -> new IllegalStateException("엔티티 조회 실패"));
+        Assertions.assertThat(result.getStatus()).isEqualTo(STATUS.OCCUPIED);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #1

## 📌 작업 내용 및 특이사항
SolutionEntity를 한 명의 사용자만 점유할 수 있도록 동시성 제어 기능을 개발했습니다.
기존에는 단순히 상태 필드를 변경했기 때문에 멀티스레드 환경에서 동시에 여러 명이 점유할 수 있는 문제가 있었습니다. 이 문제를 해결하기 위해 비관적 락(Pessimistic Lock) 을 적용했습니다.

## 📝 참고사항
- 

## 📚 기타
-