### PR TITLE
feat: solutionSeq로 조회 시 비관적 락을 적용한 조회 로직 추가 (#3)

### DIFF
--- a/src/main/java/startwithco/solutionservice/repository/SolutionRepository.java
+++ b/src/main/java/startwithco/solutionservice/repository/SolutionRepository.java
@@ -2,10 +2,8 @@ package startwithco.solutionservice.repository;
 
 import startwithco.solutionservice.domain.SolutionEntity;
 
-import java.util.Optional;
-
 public interface SolutionRepository {
-    Optional<SolutionEntity> findWithLockBySolutionSeqForWaiting(Long solutionSeq);
+    SolutionEntity findWithLockBySolutionSeqForWaiting(Long solutionSeq);
 
     SolutionEntity saveAndFlush(SolutionEntity entity);
 }

--- a/src/main/java/startwithco/solutionservice/repository/SolutionRepositoryImpl.java
+++ b/src/main/java/startwithco/solutionservice/repository/SolutionRepositoryImpl.java
@@ -3,6 +3,8 @@ package startwithco.solutionservice.repository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import startwithco.solutionservice.domain.SolutionEntity;
+import startwithco.solutionservice.exception.notFound.NotFoundErrorResult;
+import startwithco.solutionservice.exception.notFound.NotFoundException;
 
 import java.util.Optional;
 
@@ -12,8 +14,9 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     private final SolutionJpaRepository repository;
 
     @Override
-    public Optional<SolutionEntity> findWithLockBySolutionSeqForWaiting(Long solutionSeq) {
-        return repository.findWithLockBySolutionSeqForWaiting(solutionSeq);
+    public SolutionEntity findWithLockBySolutionSeqForWaiting(Long solutionSeq) {
+        return repository.findWithLockBySolutionSeqForWaiting(solutionSeq)
+                .orElseThrow(() -> new NotFoundException(NotFoundErrorResult.SOLUTION_NOT_FOUND_EXCEPTION));
     }
 
     @Override

--- a/src/main/java/startwithco/solutionservice/service/SolutionService.java
+++ b/src/main/java/startwithco/solutionservice/service/SolutionService.java
@@ -30,9 +30,7 @@ public class SolutionService {
 
     @Transactional
     public PaymentResponseDto getTossPaymentParam(Long solutionSeq) {
-        SolutionEntity solutionEntity = repository.findWithLockBySolutionSeqForWaiting(solutionSeq)
-                .orElseThrow(() -> new NotFoundException(NotFoundErrorResult.SOLUTION_NOT_FOUND_EXCEPTION));
-
+        SolutionEntity solutionEntity = repository.findWithLockBySolutionSeqForWaiting(solutionSeq);
         solutionEntity.occupy();
         SolutionEntity result = repository.saveAndFlush(solutionEntity);
 


### PR DESCRIPTION
- findWithLockBySolutionSeqForWaiting 메서드 구현
  - 특정 상태의 SolutionEntity를 비관적 락(PESSIMISTIC_WRITE)으로 조회
  - 조회 실패 시 NotFoundException 예외 처리 적용
- 동시성 제어 및 중복 처리 방지를 위한 로직 보완

## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- 

## 📝 참고사항
- 

## 📚 기타
-